### PR TITLE
Fix wrong string ID and do some string fixes

### DIFF
--- a/adsp.biquad.filters/resources/language/English/strings.po
+++ b/adsp.biquad.filters/resources/language/English/strings.po
@@ -26,12 +26,12 @@ msgstr ""
 
 # template configuration: src/template/configuration/templateConfiguration.cpp
 msgctxt "#30001"
-msgid "Setup Parametric EQ"
+msgid "Setup - Parametric EQ"
 msgstr ""
 
 # template configuration: src/template/configuration/templateConfiguration.cpp
 msgctxt "#30002"
-msgid "10 frequency bands + post gain"
+msgid "10 frequency bands plus post gain"
 msgstr ""
 
 # template configuration: src/template/configuration/templateConfiguration.cpp
@@ -46,17 +46,17 @@ msgstr ""
 
 # Parametric EQ Addon Settings: resources/settings.xml
 msgctxt "#30120"
-msgid "Enable Postprocess Parametric EQ"
+msgid "Enable post-processing - Parametric EQ"
 msgstr ""
 
 # Parametric EQ Addon Settings: resources/settings.xml
-msgctxt "#30111"
-msgid "Enable Preprocess Parametric EQ"
+msgctxt "#30121"
+msgid "Enable pre-processing - Parametric EQ"
 msgstr ""
 
-# Parametric EQ Addon Settings: resources/parametricEQSettings.xml
+# Parametric EQ Addon Settings: resources/settings.xml
 msgctxt "#30122"
-msgid "Enable Parameter Fading"
+msgid "Enable parameter fading"
 msgstr ""
 
 # Dialog Parametric EQ: resources/skins/Confluence/720p/DialogParametricEQ.xml


### PR DESCRIPTION
Essentially settings.xml refers to "#30121" and in this file that message is "#30111" which causes the label to be missing in settings dialog see **issue 7** in http://forum.kodi.tv/showthread.php?tid=232628&pid=2057310#pid2057310

So this PR fixes that.

Also took opportunity to fix the strings and bring them up to scratch.

In my opinion this is the bare minimum to do here, but if Im honest I find repeating **Parametric EQ** in every other settings is slight redundant, unless in future there will be other types, but if not I would think its is fairly obvious and repetition is not necessary.
