### PR TITLE
add usage of -fPIC for OS other then linux to fix library build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,10 @@ find_package(platform REQUIRED)
 find_package(TinyXML REQUIRED)
 find_package(asplib REQUIRED)
 
+if (NOT WIN32)
+  add_definitions(-fPIC -g -O2)
+endif()
+
 include_directories(${kodiplatform_INCLUDE_DIRS}
                     ${platform_INCLUDE_DIRS}
                     ${TINYXML_INCLUDE_DIRS}


### PR DESCRIPTION
This fix the build on linux which brings on add-on

```
[ 94%] Linking CXX shared library adsp.biquad.filters.so
/usr/bin/ld: /home/alwin/Mupel/build/kodi-AlwinEsch/kodi-linux-x86_64/tools/depends/target/binary-addons/x86_64-linux-gnu/build/depends/lib/libasplib.a(apslib_BiquadFactory.cpp.o): relocation R_X86_64_32 against `.bss' can not be used when making a shared object; recompile with -fPIC
/home/alwin/Mupel/build/kodi-AlwinEsch/kodi-linux-x86_64/tools/depends/target/binary-addons/x86_64-linux-gnu/build/depends/lib/libasplib.a: error adding symbols: Bad value
collect2: error: ld returned 1 exit status
CMakeFiles/adsp.biquad.filters.dir/build.make:486: recipe for target 'adsp.biquad.filters.so.0.0.1' failed
make[2]: *** [adsp.biquad.filters.so.0.0.1] Error 1
CMakeFiles/Makefile2:99: recipe for target 'CMakeFiles/adsp.biquad.filters.dir/all' failed
make[1]: *** [CMakeFiles/adsp.biquad.filters.dir/all] Error 2
Makefile:149: recipe for target 'all' failed
make: *** [all] Error 2
```
