### PR TITLE
p8-platform & Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,19 @@
+#
+# Travis defaults to building on Ubuntu Precise. We need Trusty
+# in order to get up to date versions of cmake and g++
+#
+language: cpp
+sudo: required
+dist: trusty
+
+#
+# The addon source is automatically checked out in $TRAVIS_BUILD_DIR,
+# we'll put the Kodi source on the same level
+#
+before_script:
+  - cd $TRAVIS_BUILD_DIR/..
+  - git clone --depth=1 https://github.com/xbmc/xbmc.git
+  - cd adsp.biquad.filters && mkdir build && cd build
+  - cmake -DADDONS_TO_BUILD=adsp.biquad.filters -DADDON_SRC_PREFIX=../.. -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=../../xbmc/addons -DPACKAGE_ZIP=1 ../../xbmc/project/cmake/addons
+
+script: make

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,12 +8,12 @@ enable_language(CXX)
 
 find_package(kodi REQUIRED)
 find_package(kodiplatform REQUIRED)
-find_package(platform REQUIRED)
+find_package(p8-platform REQUIRED)
 find_package(TinyXML REQUIRED)
 find_package(asplib REQUIRED)
 
 include_directories(${kodiplatform_INCLUDE_DIRS}
-                    ${platform_INCLUDE_DIRS}
+                    ${p8-platform_INCLUDE_DIRS}
                     ${TINYXML_INCLUDE_DIRS}
                     ${KODI_INCLUDE_DIR}
                     ${ASPLIB_INCLUDE_DIRS}
@@ -37,7 +37,7 @@ set(TEMPLATE_SOURCES  src/DSPProcessor.cpp
                       src/template/Messages/ADSPModeMessage.cpp
                       src/template/configuration/templateConfiguration.cpp)
 
-set(DEPLIBS ${platform_LIBRARIES}
+set(DEPLIBS ${p8-platform_LIBRARIES}
             ${ASPLIB_LIBRARIES}
             ${TINYXML_LIBRARIES})
 

--- a/Findasplib.cmake
+++ b/Findasplib.cmake
@@ -12,11 +12,11 @@ endif()
 
 if(NOT ASPLIB_FOUND)
   find_path(ASPLIB_INCLUDE_DIRS "apslib_BiquadFactory.h"
-            ASPLIB_INCLUDE_DIRS "Biquads/Biquad_Native/asplib_Biquad_Native.h"
-            ASPLIB_INCLUDE_DIRS "constants_typedefs/asplib_constants.h"
-            ASPLIB_INCLUDE_DIRS "constants_typedefs/asplib_typedefs.h"
-            ASPLIB_INCLUDE_DIRS "interfaces/asplib_IBaseBiquad.h"
-            PATH_SUFFIXES "asplib" )
+                                "Biquads/Biquad_Native/asplib_Biquad_Native.h"
+                                "constants_typedefs/asplib_constants.h"
+                                "constants_typedefs/asplib_typedefs.h"
+                                "interfaces/asplib_IBaseBiquad.h"
+                                PATH_SUFFIXES "asplib" )
 
   find_library(ASPLIB_LIBRARIES
                NAMES "asplib"

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Linux Build Status](https://travis-ci.org/AchimTuran/adsp.biquad.filters.svg?branch=master)](https://travis-ci.org/AchimTuran/adsp.biquad.filters)
+
 # Biquad Filters
 A AudioDSP Addon for Kodi. 
 The following processing modes are available:

--- a/depends/common/asplib/asplib.txt
+++ b/depends/common/asplib/asplib.txt
@@ -1,1 +1,1 @@
-asplib https://github.com/kodi-adsp/asplib release-0.0.1__kodi-adsp
+asplib https://github.com/AchimTuran/asplib build_fixes

--- a/src/template/ADSPAddonHandler.cpp
+++ b/src/template/ADSPAddonHandler.cpp
@@ -19,7 +19,7 @@
  */
 
 #include <string>
-#include <platform/util/util.h>
+#include <p8-platform/util/util.h>
 
 #include "include/client.h"
 
@@ -34,6 +34,7 @@
 
 using namespace std;
 using namespace ADDON;
+using namespace P8PLATFORM;
 
 extern std::string adspImageUserPath;
 
@@ -54,7 +55,7 @@ CADSPAddonHandler::CADSPAddonHandler()
 
 CADSPAddonHandler::~CADSPAddonHandler()
 {
-  PLATFORM::CLockObject modeLock(m_ADSPModeLock);
+  CLockObject modeLock(m_ADSPModeLock);
 
   for( unsigned int ii = 0; ii < AE_DSP_STREAM_MAX_STREAMS; ii++ )
   {
@@ -215,7 +216,7 @@ bool CADSPAddonHandler::Init()
 
 void CADSPAddonHandler::Destroy()
 {
-  PLATFORM::CLockObject modeLock(m_ADSPModeLock);
+  CLockObject modeLock(m_ADSPModeLock);
 
   for(int ii = 0; ii < AE_DSP_STREAM_MAX_STREAMS; ii++)
   {
@@ -235,7 +236,7 @@ AE_DSP_ERROR CADSPAddonHandler::StreamCreate(const AE_DSP_SETTINGS *addonSetting
     return AE_DSP_ERROR_UNKNOWN;
   }
 
-  PLATFORM::CLockObject modeLock(m_ADSPModeLock);
+  CLockObject modeLock(m_ADSPModeLock);
   if(m_ADSPProcessor[iStreamID])
   {
     delete m_ADSPProcessor[iStreamID];
@@ -267,7 +268,7 @@ AE_DSP_ERROR CADSPAddonHandler::StreamDestroy(unsigned int Id)
 		return AE_DSP_ERROR_UNKNOWN;
 	}
 
-  PLATFORM::CLockObject modeLock(m_ADSPModeLock);
+  CLockObject modeLock(m_ADSPModeLock);
 	if(m_ADSPProcessor[Id])
 	{
 		delete m_ADSPProcessor[Id];
@@ -306,7 +307,7 @@ AE_DSP_ERROR CADSPAddonHandler::GetStreamInfos(AE_DSP_STREAM_ID Id, const AE_DSP
     return AE_DSP_ERROR_INVALID_PARAMETERS;
   }
 
-  PLATFORM::CLockObject modeLock(m_ADSPModeLock);
+  CLockObject modeLock(m_ADSPModeLock);
   if(!m_ADSPProcessor[Id])
   {
     return AE_DSP_ERROR_REJECTED;
@@ -331,7 +332,7 @@ AE_DSP_ERROR CADSPAddonHandler::SendMessageToStream(CADSPModeMessage &Message)
     unsigned int failedMessages = 0;
     for(unsigned int stream = 0; stream < AE_DSP_STREAM_MAX_STREAMS; stream++)
     {
-      PLATFORM::CLockObject modeLock(m_ADSPModeLock);
+      CLockObject modeLock(m_ADSPModeLock);
       if(m_ADSPProcessor[stream])
       {
         AE_DSP_ERROR err = m_ADSPProcessor[stream]->send_Message(Message);
@@ -357,7 +358,7 @@ AE_DSP_ERROR CADSPAddonHandler::SendMessageToStream(CADSPModeMessage &Message)
       return AE_DSP_ERROR_INVALID_PARAMETERS;
     }
 
-    PLATFORM::CLockObject modeLock(m_ADSPModeLock);
+    CLockObject modeLock(m_ADSPModeLock);
     if(!m_ADSPProcessor[Message.get_StreamId()])
     {
       return AE_DSP_ERROR_IGNORE_ME;

--- a/src/template/client.cpp
+++ b/src/template/client.cpp
@@ -29,7 +29,7 @@
 
 // include kodi platform header files
 #include <kodi/kodi_adsp_dll.h>
-#include <platform/util/util.h>
+#include <p8-platform/util/util.h>
 
 // include adsp template specific header files
 #include "include/client.h"

--- a/src/template/include/ADSPAddonHandler.h
+++ b/src/template/include/ADSPAddonHandler.h
@@ -21,7 +21,7 @@
 
 #include <string>
 #include <kodi/kodi_adsp_types.h>
-#include <platform/threads/mutex.h>
+#include <p8-platform/threads/mutex.h>
 
 #include "../configuration/templateConfiguration.h"
 #include "ADSPProcessorHandle.h"
@@ -93,7 +93,7 @@ public:
   /*!
    * Mutex for safe access to processing modes
    */
-   PLATFORM::CMutex m_ADSPModeLock;
+   P8PLATFORM::CMutex m_ADSPModeLock;
 
 private:
 	//AE_DSP_SETTINGS           m_Settings;           /*!< @brief (required) the active XBMC audio settings */


### PR DESCRIPTION
This PR adapts to the library name change from platfrom to p-platform.
Futhermore it add Travis CI builds for Linux.
