### PR TITLE
[cmake] Rename find_package(kodi) to Kodi

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR})
 
 enable_language(CXX)
 
-find_package(kodi REQUIRED)
+find_package(Kodi REQUIRED)
 find_package(kodiplatform REQUIRED)
 find_package(p8-platform REQUIRED)
 find_package(TinyXML REQUIRED)

--- a/adsp.biquad.filters/addon.xml.in
+++ b/adsp.biquad.filters/addon.xml.in
@@ -10,15 +10,11 @@
   </requires>
   <extension
     point="kodi.adsp"
-    library_linux="adsp.biquad.filters.so"
-    library_osx="adsp.biquad.filters.dylib"
-    library_wingl="adsp.biquad.filters.dll"
-    library_windx="adsp.biquad.filters.dll"
-    library_android="libadsp.biquad.filters.so" />
+    library_@PLATFORM@="@LIBRARY_FILENAME@"/>
   <extension point="kodi.addon.metadata">
     <summary lang="en">Includes an equalizer post processing mode</summary>
     <description lang="en">The first version of this add-on includes a parametric equalizer post processing mode with constant-Q peaking filters (biquad filter). It allows you to boost or cut 10 frequency bands.</description>
     <disclaimer lang="en">Note: it's the first version. Consequently please use a low audio volume at first, which can protect your ears.</disclaimer>
-    <platform>all</platform>
+    <platform>@PLATFORM@</platform>
   </extension>
 </addon>

--- a/src/Messages/BiquadMessage_types.h
+++ b/src/Messages/BiquadMessage_types.h
@@ -22,7 +22,7 @@
 
 
 #include <asplib/Biquads/apslib_BiquadFactory.h>
-#include <kodi/kodi_adsp_types.h>
+#include <kodi_adsp_types.h>
 #include "template/ADSPHelpers.h"
 #include <vector>
 

--- a/src/template/ADSPHelpers.h
+++ b/src/template/ADSPHelpers.h
@@ -24,7 +24,7 @@
 #include <string>
 // reserved for future implementation
 //#include <exception>
-#include <kodi/kodi_adsp_types.h>
+#include <kodi_adsp_types.h>
 #include "AddonHelpers.h"
 
 typedef unsigned long AE_DSP_CHANNEL_FLAGS;

--- a/src/template/Settings/SettingsManager.cpp
+++ b/src/template/Settings/SettingsManager.cpp
@@ -26,7 +26,7 @@
 #include "SettingsHelpers.h"
 #include "SettingsManager.h"
 #include "../AddonExceptions/TAddonException.h"
-#include "kodi/libXBMC_addon.h"
+#include "libXBMC_addon.h"
 #include "exception"
 
 using namespace ADDON;

--- a/src/template/client.cpp
+++ b/src/template/client.cpp
@@ -28,7 +28,7 @@
 #include "include/checkTemplateConfig.h"
 
 // include kodi platform header files
-#include <kodi/kodi_adsp_dll.h>
+#include <kodi_adsp_dll.h>
 #include <p8-platform/util/util.h>
 
 // include adsp template specific header files

--- a/src/template/include/ADSPAddonHandler.h
+++ b/src/template/include/ADSPAddonHandler.h
@@ -20,7 +20,7 @@
  */
 
 #include <string>
-#include <kodi/kodi_adsp_types.h>
+#include <kodi_adsp_types.h>
 #include <p8-platform/threads/mutex.h>
 
 #include "../configuration/templateConfiguration.h"

--- a/src/template/include/ADSPModeMessage.h
+++ b/src/template/include/ADSPModeMessage.h
@@ -20,7 +20,7 @@
 
 
 
-#include <kodi/kodi_adsp_types.h>
+#include <kodi_adsp_types.h>
 
 // typedefs
 typedef unsigned char uint8_t;

--- a/src/template/include/ADSPProcessorHandle.h
+++ b/src/template/include/ADSPProcessorHandle.h
@@ -19,7 +19,7 @@
  *
  */
 
-#include <kodi/kodi_adsp_types.h>
+#include <kodi_adsp_types.h>
 #include "../configuration/templateConfiguration.h"
 #include "template/include/MACROHelper.h"
 #include ADSP_PROCESSOR_HEADER_FILE

--- a/src/template/include/GUIDialogBase.h
+++ b/src/template/include/GUIDialogBase.h
@@ -21,7 +21,7 @@
 
 #include "client.h"
 #include <string>
-#include <kodi/libKODI_guilib.h>
+#include <libKODI_guilib.h>
 
 class CGUIDialogBase
 {

--- a/src/template/include/IADSPProcessor.h
+++ b/src/template/include/IADSPProcessor.h
@@ -19,7 +19,7 @@
  *
  */
 
-#include <kodi/kodi_adsp_types.h>
+#include <kodi_adsp_types.h>
 #include "../configuration/templateConfiguration.h"
 
 //!	This is the interface class and you must derive your processing class from this interface.

--- a/src/template/include/client.h
+++ b/src/template/include/client.h
@@ -20,9 +20,9 @@
  *
  */
 
-#include <kodi/libXBMC_addon.h>
-#include <kodi/libKODI_adsp.h>
-#include <kodi/libKODI_guilib.h>
+#include <libXBMC_addon.h>
+#include <libKODI_adsp.h>
+#include <libKODI_guilib.h>
 
 extern bool                          m_bCreated;
 extern std::string                   g_strUserPath;


### PR DESCRIPTION
Needed after https://github.com/xbmc/xbmc/pull/9750 goes in
